### PR TITLE
Changes gulp-notify to use templates

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,9 +10,7 @@ gulp.task('default', function() {
 		.pipe(babel({
 			optional: ["runtime"]
 		}))
-		.on("error", notify.onError(function(error) {
-			return error.message;
-		}))
+		.on("error", notify.onError('<%= error.message %>'))
 		.pipe(sourcemaps.write('.'))
 		.pipe(gulp.dest('dist'));
 
@@ -21,9 +19,7 @@ gulp.task('default', function() {
 		.pipe(babel({
 			optional: ["runtime"]
 		}))
-		.on("error", notify.onError(function(error) {
-			return error.message;
-		}))
+		.on("error", notify.onError('<%= error.message %>'))
 		.pipe(sourcemaps.write('.'))
 		.pipe(gulp.dest('dist/src'));
 });


### PR DESCRIPTION
Power-tip: gulp-notify can use lodash templates as messages. See more documentation here: https://github.com/mikaelbr/gulp-notify#notifystring